### PR TITLE
update doctype

### DIFF
--- a/public/template.jade
+++ b/public/template.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 //if lt IE 7
     html.no-js.lt-ie9.lt-ie8.lt-ie7(lang='en')
 //if IE 7


### PR DESCRIPTION
In the following [travis.ci build](https://travis-ci.org/msrd/msrd.io/jobs/22740582) it states:

    Warning: template h5bp.jade: /home/travis/build/msrd/msrd.io/source/templates/h5bp.jade:1
      > 1| doctype 5
        2| //if lt IE 7
        3|     html.no-js.lt-ie9.lt-ie8.lt-ie7(lang='en')
        4| //if IE 7
    `doctype 5` is deprecated, you must now use `doctype html` Use --force to continue.