### PR TITLE
Shorter name for Carlos Rojas

### DIFF
--- a/source/rdlist.yaml
+++ b/source/rdlist.yaml
@@ -125,7 +125,7 @@
   Country: USA
   Email: 
 -
-  First: Carlos Jose
+  First: Carlos J.
   Last: Rojas Reyes
   City: Lima
   State: Lima


### PR DESCRIPTION
Shorter "first name" for Carlos Rojas (from "Carlos Jose" to "Carlos J.").